### PR TITLE
Fixed a bug in the query for retrieving primary key column names

### DIFF
--- a/sources/lib/Inspector/Inspector.php
+++ b/sources/lib/Inspector/Inspector.php
@@ -199,7 +199,7 @@ with
             att.attname as field
         from
             pg_catalog.pg_attribute att
-                join pg_catalog.pg_index ind on att.attrelid = ind.indexrelid
+                join pg_catalog.pg_index ind on att.attrelid = ind.indrelid AND att.attnum = ANY(ind.indkey)
         where
             :condition
         order by att.attnum asc

--- a/sources/tests/Fixture/InspectorFixture.php
+++ b/sources/tests/Fixture/InspectorFixture.php
@@ -51,6 +51,16 @@ Class InspectorFixture extends Client
         $this->executeAnonymousQuery(join('; ', $sql));
     }
 
+    public function renamePks()
+    {
+        $sql = [
+            "alter table inspector_test.with_simple_pk rename with_simple_pk_id to with_simple_pk_id_renamed",
+            "alter table inspector_test.with_complex_pk rename another_id to another_id_renamed",
+        ];
+
+        $this->executeAnonymousQuery(join('; ', $sql));
+    }
+
     public function dropSchema()
     {
         $sql = "drop schema if exists inspector_test cascade";

--- a/sources/tests/Unit/Inspector/Inspector.php
+++ b/sources/tests/Unit/Inspector/Inspector.php
@@ -128,6 +128,18 @@ class Inspector extends FoundationSessionAtoum
             ->array($inspector->getPrimaryKey($this->getTableOid('with_complex_pk')))
             ->isIdenticalTo(['another_id', 'with_complex_pk_id'])
             ;
+
+        $this->getFixture()->renamePks();
+
+        $this
+            ->array($inspector->getPrimaryKey($this->getTableOid('no_pk')))
+            ->isEmpty()
+            ->array($inspector->getPrimaryKey($this->getTableOid('with_simple_pk')))
+            ->isIdenticalTo(['with_simple_pk_id_renamed'])
+            ->array($inspector->getPrimaryKey($this->getTableOid('with_complex_pk')))
+            ->isIdenticalTo(['another_id_renamed', 'with_complex_pk_id'])
+        ;
+
     }
 
     public function testGetSchemaOid()


### PR DESCRIPTION
This query returned the column names of the index instead of the table.

As a result, when altering a PK column name on the table, the getPrimaryKey method did still return the old and not the new column names.

This fixes issue https://github.com/pomm-project/Cli/issues/12