### PR TITLE
Added facade methods to make the API introspectable by editors and enable autocompletion

### DIFF
--- a/sources/lib/Session/Session.php
+++ b/sources/lib/Session/Session.php
@@ -299,7 +299,7 @@ ERROR;
      */
     public function getQueryManager($identifier = null)
     {
-        return $this->getClientUsingPooler('prepared_query', $identifier);
+        return $this->getClientUsingPooler('query_manager', $identifier);
     }
 
     /**
@@ -311,7 +311,7 @@ ERROR;
      */
     public function getPreparedQueryManager($identifier = null)
     {
-        return $this->getClientUsingPooler('prepared_query_manager', $identifier);
+        return $this->getClientUsingPooler('prepared_query', $identifier);
     }
 
     /**

--- a/sources/lib/Session/Session.php
+++ b/sources/lib/Session/Session.php
@@ -291,6 +291,45 @@ ERROR;
     }
 
     /**
+     * Get query manager shortcut
+     *
+     * @param   string                   $identifier
+     * @throws  FoundationException      if no poolers found
+     * @return  \PommProject\Foundation\QueryManager\QueryManagerClient
+     */
+    public function getQueryManager($identifier = null)
+    {
+        return $this->getClientUsingPooler('prepared_query', $identifier);
+    }
+
+    /**
+     * Get prepared query manager shortcut
+     *
+     * @param   string $identifier
+     * @throws  FoundationException      if no poolers found
+     * @return  \PommProject\Foundation\PreparedQuery\PreparedQueryManager
+     */
+    public function getPreparedQueryManager($identifier = null)
+    {
+        return $this->getClientUsingPooler('prepared_query_manager', $identifier);
+    }
+
+    /**
+     * Get model shortcut
+     *
+     * Without the pomm-project/model-manage package or if the class name
+     * does not exist, this method raise a FoundationException.
+     *
+     * @param   string                   $className model class name
+     * @throws  FoundationException      if no poolers found
+     * @return  \PommProject\ModelManager\Model\Model
+     */
+    public function getModel($className)
+    {
+        return $this->getClientUsingPooler('model', $className);
+    }
+
+    /**
      * __call
      *
      * Create handy methods to access clients through a pooler.


### PR DESCRIPTION
Added:
 * Session::getQueryManager()
 * Session::getPreparedQueryManager()
 * Session::getModel()

For the last one, maybe the right place to live for it is into a Session child class into the symfony/silex bridge?