### PR TITLE
PHPDoc improved: fixing missing tags, params & var

### DIFF
--- a/sources/lib/Client/ClientPoolerTrait.php
+++ b/sources/lib/Client/ClientPoolerTrait.php
@@ -113,6 +113,7 @@ trait ClientPoolerTrait
      *
      * @access protected
      * @return Session
+     * @throws FoundationException
      */
     protected function getSession()
     {

--- a/sources/lib/Client/ClientTrait.php
+++ b/sources/lib/Client/ClientTrait.php
@@ -50,7 +50,7 @@ trait ClientTrait
      * All subclasses of Client have to use this method to access the session.
      *
      * @access protected
-     * @throw  FoundationException if Session is not set.
+     * @throws  FoundationException if Session is not set.
      * @return Session
      */
     protected function getSession()

--- a/sources/lib/ConvertedResultIterator.php
+++ b/sources/lib/ConvertedResultIterator.php
@@ -56,7 +56,7 @@ class ConvertedResultIterator extends ResultIterator
      *
      * Get the result types from the result handler.
      *
-     * @access protectd
+     * @access protected
      * @return ResultIterator $this
      */
     protected function initTypes()

--- a/sources/lib/Converter/ConverterClient.php
+++ b/sources/lib/Converter/ConverterClient.php
@@ -34,7 +34,7 @@ class ConverterClient extends Client
      *
      * @access public
      * @param  string    $name
-     * @param  Converter $converter
+     * @param  ConverterInterface $converter
      * @return void
      */
     public function __construct($name, ConverterInterface $converter)

--- a/sources/lib/Converter/ConverterHolder.php
+++ b/sources/lib/Converter/ConverterHolder.php
@@ -59,7 +59,7 @@ class ConverterHolder
      * @param  string             $name
      * @param  ConverterInterface $converter
      * @param  bool               $strict (default true)
-     * @throw  ConverterException if $name already exists and strict.
+     * @throws  ConverterException if $name already exists and strict.
      * @return ConverterHolder    $this
      */
     protected function addConverter($name, ConverterInterface $converter, $strict = null)
@@ -132,7 +132,7 @@ class ConverterHolder
      * @access public
      * @param  string          $name
      * @param  string          $type
-     * @throw  ConverterException if $name does not exist.
+     * @throws  ConverterException if $name does not exist.
      * @return ConverterHolder $this
      */
     public function addTypeToConverter($name, $type)
@@ -159,7 +159,7 @@ class ConverterHolder
      *
      * @access public
      * @param  string             $type
-     * @throw  ConverterException if there are no converters associated.
+     * @throws  ConverterException if there are no converters associated.
      * @return ConverterInterface
      */
     public function getConverterForType($type)

--- a/sources/lib/Converter/ConverterPooler.php
+++ b/sources/lib/Converter/ConverterPooler.php
@@ -73,7 +73,7 @@ class ConverterPooler extends ClientPooler
      * If not, an exception is thrown.
      *
      * @see   ClientPooler
-     * @throw ConverterException
+     * @throws ConverterException
      */
     public function createClient($identifier)
     {

--- a/sources/lib/Converter/PgComposite.php
+++ b/sources/lib/Converter/PgComposite.php
@@ -116,6 +116,7 @@ class PgComposite extends ArrayTypeConverter
      * @access private
      * @param  array $data
      * @param  Session $session
+     * @param  string $method
      * @return array
      */
     private function convertArray(array $data, Session $session, $method)

--- a/sources/lib/Converter/PgHstore.php
+++ b/sources/lib/Converter/PgHstore.php
@@ -75,6 +75,7 @@ class PgHstore extends ArrayTypeConverter
      *
      * @access protected
      * @param  array $data
+     * @param  Session $session
      * @return array
      */
     protected function buildArray(array $data, Session $session)

--- a/sources/lib/Converter/PgInterval.php
+++ b/sources/lib/Converter/PgInterval.php
@@ -71,7 +71,7 @@ class PgInterval implements ConverterInterface
      * @access protected
      * @param  mixed $data
      * @throws ConverterException
-     * @return DateInterval $data
+     * @return \DateInterval $data
      */
     protected function checkData($data)
     {

--- a/sources/lib/Converter/PgJson.php
+++ b/sources/lib/Converter/PgJson.php
@@ -107,7 +107,7 @@ class PgJson implements ConverterInterface
      *
      * @access protected
      * @param  mixed $data
-     * @throw  ConverterException
+     * @throws  ConverterException
      * @return string
      */
     protected function jsonEncode($data)

--- a/sources/lib/Converter/PgTimestamp.php
+++ b/sources/lib/Converter/PgTimestamp.php
@@ -74,7 +74,7 @@ class PgTimestamp implements ConverterInterface
      *
      * @access protected
      * @param  mixed $data
-     * @throws  \ConverterException
+     * @throws ConverterException
      * @return \DateTime
      */
     protected function checkData($data)

--- a/sources/lib/Converter/PgTimestamp.php
+++ b/sources/lib/Converter/PgTimestamp.php
@@ -74,7 +74,7 @@ class PgTimestamp implements ConverterInterface
      *
      * @access protected
      * @param  mixed $data
-     * @throw  \ConverterException
+     * @throws  \ConverterException
      * @return \DateTime
      */
     protected function checkData($data)

--- a/sources/lib/Converter/Type/BaseRange.php
+++ b/sources/lib/Converter/Type/BaseRange.php
@@ -65,6 +65,7 @@ abstract class BaseRange
      * @access public
      * @param  string $description
      * @return void
+     * @throws \InvalidArgumentException
      */
 
     public function __construct($description)

--- a/sources/lib/Converter/Type/Circle.php
+++ b/sources/lib/Converter/Type/Circle.php
@@ -32,6 +32,7 @@ class Circle
      * @access public
      * @param  string $description
      * @return void
+     * @throws \InvalidArgumentException
      */
     public function __construct($description)
     {

--- a/sources/lib/Converter/TypeConverter.php
+++ b/sources/lib/Converter/TypeConverter.php
@@ -128,6 +128,7 @@ abstract class TypeConverter implements ConverterInterface
      * @access protected
      * @param  mixed $data
      * @return BaseRange
+     * @throws ConverterException
      */
     protected function createObjectFrom($data)
     {

--- a/sources/lib/Inspector/InspectorPooler.php
+++ b/sources/lib/Inspector/InspectorPooler.php
@@ -11,6 +11,7 @@ namespace PommProject\Foundation\Inspector;
 
 use PommProject\Foundation\Client\ClientPooler;
 use PommProject\Foundation\Client\ClientPoolerInterface;
+use PommProject\Foundation\Exception\FoundationException;
 
 /**
  * InspectorPooler
@@ -55,6 +56,7 @@ class InspectorPooler extends ClientPooler
      *
      * @see    ClientPooler
      * @return Inspector
+     * @throws FoundationException
      */
     protected function createClient($identifier)
     {

--- a/sources/lib/Listener/Listener.php
+++ b/sources/lib/Listener/Listener.php
@@ -38,7 +38,7 @@ class Listener extends Client
      *
      * @access public
      * @param  string $name
-     * @return null
+     * @return void
      */
     public function __construct($name)
     {

--- a/sources/lib/Listener/Listener.php
+++ b/sources/lib/Listener/Listener.php
@@ -72,7 +72,7 @@ class Listener extends Client
      *
      * @access public
      * @param  callable $action
-     * @throw  FoundationException if $action is not a callable.
+     * @throws  FoundationException if $action is not a callable.
      * @return Listener $this
      */
     public function attachAction(callable $action)

--- a/sources/lib/Observer/Observer.php
+++ b/sources/lib/Observer/Observer.php
@@ -170,7 +170,7 @@ class Observer extends Client
      * Check if a notification is pending. If so, a NotificationException is thrown.
      *
      * @access public
-     * @throw  NotificationException
+     * @throws  NotificationException
      * @return Observer $this
      */
     public function throwNotification()

--- a/sources/lib/Observer/Observer.php
+++ b/sources/lib/Observer/Observer.php
@@ -110,7 +110,7 @@ class Observer extends Client
      * transaction.
      *
      * @access public
-     * @return Otherwise $this
+     * @return Observer $this
      */
     public function restartListening()
     {
@@ -127,7 +127,7 @@ class Observer extends Client
      *
      * @access protected
      * @param  string    $channel
-     * @return Otherwise $this
+     * @return Observer $this
      */
     protected function listen($channel)
     {

--- a/sources/lib/Observer/ObserverPooler.php
+++ b/sources/lib/Observer/ObserverPooler.php
@@ -25,7 +25,7 @@ use PommProject\Foundation\Client\ClientPooler;
  */
 class ObserverPooler extends ClientPooler
 {
-    /*
+    /**
      * getPoolerType
      *
      * @see ClientPoolerInterface

--- a/sources/lib/Pager.php
+++ b/sources/lib/Pager.php
@@ -164,7 +164,7 @@ class Pager
      * Get maximum result per page.
      *
      * @access public
-     * @return Interger
+     * @return int
      */
     public function getMaxPerPage()
     {

--- a/sources/lib/ParameterHolder.php
+++ b/sources/lib/ParameterHolder.php
@@ -96,7 +96,7 @@ class ParameterHolder implements \ArrayAccess, \IteratorAggregate, \Countable
      * Throw an exception if a param is not set
      *
      * @access public
-     * @throw  FoundationException
+     * @throws  FoundationException
      * @param  string          $name the parameter's name
      * @return ParameterHolder $this
      */
@@ -135,7 +135,7 @@ class ParameterHolder implements \ArrayAccess, \IteratorAggregate, \Countable
      * not, an exception is thrown.
      *
      * @access public
-     * @throw  FoundationException
+     * @throws  FoundationException
      * @param  string          $name   the parameter's name
      * @param  array           $values
      * @return ParameterHolder $this

--- a/sources/lib/Pomm.php
+++ b/sources/lib/Pomm.php
@@ -109,6 +109,7 @@ class Pomm implements \ArrayAccess, LoggerAwareInterface
      * @access  public
      * @param   string  $name
      * @return  Pomm    $this
+     * @throws FoundationException
      */
     public function setDefaultBuilder($name)
     {
@@ -133,6 +134,7 @@ class Pomm implements \ArrayAccess, LoggerAwareInterface
      *
      * @access  public
      * @return  BaseSession
+     * @throws FoundationException
      */
     public function getDefaultSession()
     {

--- a/sources/lib/PreparedQuery/PreparedQuery.php
+++ b/sources/lib/PreparedQuery/PreparedQuery.php
@@ -56,6 +56,7 @@ class PreparedQuery extends Client
      * @access public
      * @param  string $sql SQL query
      * @return void
+     * @throws FoundationException
      */
     public function __construct($sql)
     {

--- a/sources/lib/PreparedQuery/PreparedQueryPooler.php
+++ b/sources/lib/PreparedQuery/PreparedQueryPooler.php
@@ -57,7 +57,7 @@ class PreparedQueryPooler extends ClientPooler
      * createClient
      *
      * @see    ClientPooler
-     * @param  string  SQL query
+     * @param  string $sql SQL query
      * @return PreparedQuery
      */
     public function createClient($sql)

--- a/sources/lib/QueryManager/QueryManagerPooler.php
+++ b/sources/lib/QueryManager/QueryManagerPooler.php
@@ -55,7 +55,7 @@ class QueryManagerPooler extends ClientPooler
      * createClient
      *
      * @see    ClientPooler
-     * @param  string   $client_class_name
+     * @param  string $client Client class name
      * @throws  FoundationException
      * @return ClientInterface
      */

--- a/sources/lib/QueryManager/QueryManagerPooler.php
+++ b/sources/lib/QueryManager/QueryManagerPooler.php
@@ -56,7 +56,7 @@ class QueryManagerPooler extends ClientPooler
      *
      * @see    ClientPooler
      * @param  string   $client_class_name
-     * @throw  FoundationException
+     * @throws  FoundationException
      * @return ClientInterface
      */
     protected function createClient($client)

--- a/sources/lib/QueryManager/QueryParameterParserTrait.php
+++ b/sources/lib/QueryManager/QueryParameterParserTrait.php
@@ -65,7 +65,7 @@ trait QueryParameterParserTrait
      * PHP representation to Postgresql data value.
      *
      * @access  public
-     * @param   mixed   SQL query.
+     * @param   mixed $string SQL query.
      * @return  array
      */
     public function getParametersType($string)

--- a/sources/lib/QueryManager/SimpleQueryManager.php
+++ b/sources/lib/QueryManager/SimpleQueryManager.php
@@ -35,7 +35,7 @@ class SimpleQueryManager extends QueryManagerClient
      * Perform a simple escaped query and return converted result iterator.
      *
      * @access public
-     * @param  sting $sql
+     * @param  string $sql
      * @param  array $parameters
      * @return ConvertedResultIterator
      */

--- a/sources/lib/QueryManager/SimpleQueryManager.php
+++ b/sources/lib/QueryManager/SimpleQueryManager.php
@@ -13,6 +13,7 @@ use PommProject\Foundation\ConvertedResultIterator;
 use PommProject\Foundation\Listener\SendNotificationTrait;
 use PommProject\Foundation\QueryManager\QueryManagerClient;
 use PommProject\Foundation\QueryManager\QueryParameterParserTrait;
+use PommProject\Foundation\Session\ResultHandler;
 
 /**
  * SimpleQueryManager

--- a/sources/lib/Session/Connection.php
+++ b/sources/lib/Session/Connection.php
@@ -79,7 +79,7 @@ class Connection
      *
      * @access public
      * @param  array               $configuration
-     * @throw  ConnectionException if connection is already up.
+     * @throws  ConnectionException if connection is already up.
      * @return Connection          $this
      */
     public function addConfiguration(array $configuration)
@@ -187,7 +187,7 @@ class Connection
      * Open a connection on the database.
      *
      * @access private
-     * @throw  ConnectionException if connection fails.
+     * @throws  ConnectionException if connection fails.
      * return  Connection $this
      */
     private function launch()

--- a/sources/lib/Session/Connection.php
+++ b/sources/lib/Session/Connection.php
@@ -47,6 +47,7 @@ class Connection
      *
      * @access public
      * @param  string $dsn
+     * @param  array $configuration
      */
     public function __construct($dsn, array $configuration = [])
     {
@@ -114,7 +115,7 @@ class Connection
      * Return the connection handler. If no connection are open, it opens one.
      *
      * @access protected
-     * @throw  ConnectionException if connection is open in a bad state.
+     * @throws  ConnectionException if connection is open in a bad state.
      * @return resource
      */
     protected function getHandler()
@@ -248,7 +249,8 @@ class Connection
      * Check if the handler is set and throw an Exception if yes.
      *
      * @access private
-     * @param  string         error_message
+     * @param  string     $error_message
+     * @throws ConnectionException
      * @return Connection $this
      */
     private function checkConnectionUp($error_message = '')
@@ -292,8 +294,8 @@ class Connection
      *
      * @access protected
      * @param  string (default null)
-     * @throw  ConnectionException if no response are available.
-     * @throw  SqlException if the result is an error.
+     * @throws  ConnectionException if no response are available.
+     * @throws  SqlException if the result is an error.
      * @return ResultHandler|array
      */
     protected function getQueryResult($sql = null)
@@ -345,7 +347,7 @@ class Connection
      * Escape a text value.
      *
      * @access public
-     * @param  string The string to be escaped
+     * @param  string $string The string to be escaped
      * @return string the escaped string.
      */
     public function escapeLiteral($string)
@@ -389,6 +391,7 @@ class Connection
      * @access public
      * @param  string        $query
      * @param  array         $parameters
+     * @throws ConnectionException
      * @return ResultHandler query result wrapper
      */
     public function sendQueryWithParameters($query, array $parameters = [])
@@ -447,6 +450,7 @@ class Connection
      * @access protected
      * @param  mixed      $query_return
      * @param  string     $sql
+     * @throws ConnectionException
      * @return Connection $this
      */
     protected function testQuery($query_return, $sql)

--- a/sources/lib/Session/ConnectionConfigurator.php
+++ b/sources/lib/Session/ConnectionConfigurator.php
@@ -101,8 +101,8 @@ class ConnectionConfigurator
      * Sets the different parameters from the DSN.
      *
      * @access private
-     * @param  string         DSN
      * @return Connection $this
+     * @throws ConnectionException
      */
     private function parseDsn()
     {
@@ -118,7 +118,7 @@ class ConnectionConfigurator
         $adapter = $matchs[1];
 
         if ($matchs[2] === null) {
-            throw ConnectionException(sprintf('No user information in dsn "%s".', $dsn));
+            throw new ConnectionException(sprintf('No user information in dsn "%s".', $dsn));
         }
 
         $user = $matchs[2];
@@ -199,6 +199,7 @@ class ConnectionConfigurator
      *
      * @access public
      * @return array
+     * @throws ConnectionException
      */
     public function getConfiguration()
     {

--- a/sources/lib/Session/ResultHandler.php
+++ b/sources/lib/Session/ResultHandler.php
@@ -82,7 +82,7 @@ class ResultHandler
      *
      * @access public
      * @param  int   $index
-     * @throw OutOfBoundsException if $index out of bounds.
+     * @throws OutOfBoundsException if $index out of bounds.
      * @return array
      */
     public function fetchRow($index)
@@ -230,7 +230,7 @@ class ResultHandler
      *
      * @access public
      * @param  string   $name
-     * @throw  FoundationException on error
+     * @throws  FoundationException on error
      * @return int|null
      */
     public function getTypeOid($name)

--- a/sources/lib/Session/ResultHandler.php
+++ b/sources/lib/Session/ResultHandler.php
@@ -102,7 +102,7 @@ class ResultHandler
      * Return the number of fields of a result.
      *
      * @access public
-     * @return long
+     * @return int long
      */
     public function countFields()
     {
@@ -115,7 +115,7 @@ class ResultHandler
      * Return the number of rows in a result.
      *
      * @access public
-     * @return long
+     * @return int long
      */
     public function countRows()
     {
@@ -147,7 +147,7 @@ class ResultHandler
      * Return the associated type of a field.
      *
      * @access public
-     * @param  int    $field_no
+     * @param  int $name
      * @return string
      */
     public function getFieldType($name)
@@ -183,7 +183,7 @@ class ResultHandler
      *
      * @access protected
      * @param  string $name
-     * @return long
+     * @return int long
      */
     protected function getFieldNumber($name)
     {

--- a/sources/lib/Session/ResultHandler.php
+++ b/sources/lib/Session/ResultHandler.php
@@ -82,7 +82,7 @@ class ResultHandler
      *
      * @access public
      * @param  int   $index
-     * @throws OutOfBoundsException if $index out of bounds.
+     * @throws \OutOfBoundsException if $index out of bounds.
      * @return array
      */
     public function fetchRow($index)
@@ -165,6 +165,7 @@ class ResultHandler
      * @access public
      * @param  int    $field_no
      * @return string
+     * @throws \Exception
      */
     public function getFieldName($field_no)
     {

--- a/sources/lib/Session/Session.php
+++ b/sources/lib/Session/Session.php
@@ -298,7 +298,7 @@ ERROR;
      * @access  public
      * @param   string                   $method
      * @param   array                    $arguments
-     * @throws  BadFunctionCallException if unknown method
+     * @throws  \BadFunctionCallException if unknown method
      * @throws  FoundationException      if no poolers found
      * @return  ClientInterface
      */

--- a/sources/lib/Session/Session.php
+++ b/sources/lib/Session/Session.php
@@ -50,6 +50,7 @@ class Session implements LoggerAwareInterface
      *
      * @access  public
      * @param   Connection       $connection
+     * @param   ClientHolder     $client_holder
      * @param   string           $stamp
      * @return  null
      */
@@ -141,7 +142,7 @@ class Session implements LoggerAwareInterface
      * client holder.
      *
      * @access  public
-     * @param   Client  $client
+     * @param   ClientInterface $client
      * @return  Session $this
      */
     public function registerClient(ClientInterface $client)

--- a/sources/lib/Session/SessionBuilder.php
+++ b/sources/lib/Session/SessionBuilder.php
@@ -169,7 +169,7 @@ class SessionBuilder
      *
      * @access protected
      * @param  string   $dsn
-     * @param  string   $connection_configuration
+     * @param  array  $connection_configuration
      * @return Connection
      */
     protected function createConnection($dsn, $connection_configuration)


### PR DESCRIPTION
Just figured out that the actual PHPDoc tag name is [`throws`](http://phpdoc.org/docs/latest/references/phpdoc/tags/throws.html), not `@throw` ;-)
Credit goes to PhpStorm code sniffer tools.