### PR TITLE
[improvement] remove try catch for method sendQueryWithParameters so …

### DIFF
--- a/sources/lib/Exception/SqlException.php
+++ b/sources/lib/Exception/SqlException.php
@@ -300,6 +300,7 @@ class SqlException extends FoundationException
 
     protected $result_resource;
     protected $sql;
+    protected $queryParamters;
 
     /**
      * __construct
@@ -325,6 +326,7 @@ class SqlException extends FoundationException
             $code,
             $e
         );
+        $this->queryParamters = array();
     }
 
     /**
@@ -377,5 +379,21 @@ class SqlException extends FoundationException
     public function getSQLDetailedErrorMessage()
     {
         return sprintf("«%s»\n%s\n(%s)", pg_result_error_field($this->result_resource, \PGSQL_DIAG_MESSAGE_PRIMARY), pg_result_error_field($this->result_resource, \PGSQL_DIAG_MESSAGE_DETAIL), pg_result_error_field($this->result_resource, \PGSQL_DIAG_MESSAGE_HINT));
+    }
+
+    public function getQuery()
+    {
+        return $this->sql;
+    }
+
+    public function setQueryParameters(array $parameters)
+    {
+        $this->queryParamters = $parameters;
+        return $this;
+    }
+
+    public function getQueryParameters()
+    {
+        return $this->queryParamters;
     }
 }

--- a/sources/lib/Exception/SqlException.php
+++ b/sources/lib/Exception/SqlException.php
@@ -300,7 +300,7 @@ class SqlException extends FoundationException
 
     protected $result_resource;
     protected $sql;
-    protected $queryParamters;
+    protected $queryParameters;
 
     /**
      * __construct
@@ -326,7 +326,7 @@ class SqlException extends FoundationException
             $code,
             $e
         );
-        $this->queryParamters = array();
+        $this->queryParameters = array();
     }
 
     /**
@@ -388,12 +388,12 @@ class SqlException extends FoundationException
 
     public function setQueryParameters(array $parameters)
     {
-        $this->queryParamters = $parameters;
+        $this->queryParameters = $parameters;
         return $this;
     }
 
     public function getQueryParameters()
     {
-        return $this->queryParamters;
+        return $this->queryParameters;
     }
 }

--- a/sources/lib/Session/Connection.php
+++ b/sources/lib/Session/Connection.php
@@ -402,21 +402,10 @@ class Connection
             $parameters
         );
 
-        try {
-            return $this
-                ->testQuery($res, $query)
-                ->getQueryResult($query)
-                ;
-        } catch (SqlException $e) {
-            throw new ConnectionException(
-                sprintf(
-                    "Parameters = {%s}.",
-                    print_r($parameters, true)
-                ),
-                null,
-                $e
-            );
-        }
+        return $this
+            ->testQuery($res, $query)
+            ->getQueryResult($query)
+            ;
     }
 
     /**

--- a/sources/lib/Session/Connection.php
+++ b/sources/lib/Session/Connection.php
@@ -402,10 +402,15 @@ class Connection
             $parameters
         );
 
-        return $this
-            ->testQuery($res, $query)
-            ->getQueryResult($query)
-            ;
+        try {
+            return $this
+                ->testQuery($res, $query)
+                ->getQueryResult($query)
+                ;
+        } catch(SqlException $e) {
+            throw $e->setQueryParameters($parameters);
+        }
+
     }
 
     /**

--- a/sources/tests/Unit/Session/Connection.php
+++ b/sources/tests/Unit/Session/Connection.php
@@ -47,4 +47,28 @@ class Connection extends Atoum
             ->isInstanceOf('\PommProject\Foundation\Exception\SqlException')
             ;
     }
+
+    public function testSendQueryWithParameters()
+    {
+        $badQuery = 'select n where true = $1';
+        $parameters = array(true);
+
+        $connection = $this->getConnection($this->getDsn());
+        $this
+            ->object($connection->sendQueryWithParameters('select true where true = $1', $parameters))
+            ->isInstanceOf('\PommProject\Foundation\Session\ResultHandler')
+            ->exception(function() use ($connection, $badQuery, $parameters) {
+                $connection->sendQueryWithParameters($badQuery, $parameters);
+            })
+            ->isInstanceOf('\PommProject\Foundation\Exception\SqlException')
+            ->string($this->exception->getSQLErrorState())
+            ->isIdenticalTo(SqlException::UNDEFINED_COLUMN)
+            ->and
+            ->array($this->exception->getQueryParameters())
+            ->isIdenticalTo($parameters)
+            ->and
+            ->string($this->exception->getQuery())
+            ->isIdenticalTo($badQuery)
+        ;
+    }
 }


### PR DESCRIPTION
Hi, we are using pomm-project foundation in our silex app. It provides us good way to access our postgresql database. So first of all thanks for your work :smile: :+1: !

We are currently using the simpleQueryManager::query to query the DB. We think there a small issue when using your lib concerning erro management. 

**Let me expose our problem :**
When there is a database problem (for example a malformed db query), it would be nice to take advantage of the SQLException class to have a complete error report. Instead, the SQLException is swallowed and added in the trace in a ConnectionException. This is not very convenient because we can't use the silex error listener to log SQLException. 

Also we get really ugly error messages, for example when using SQLException we can get something like that : 

```
"title": "SQL Exception",
"severity": "ERROR",
"detail": "«column n.ids does not exist»\n\n()"
```
whereas with a ConnectionException we get this kind of messages :

```
"title": "Connection Exception",
"detail": "Parameters = {Array\n(\n)\n}."
```
Not very convenient IMHO.

**Solution proposed::**
I modified the connection class and removed the try catch so that we can access a SQLException when using simpleQueryManager::query. It passes **every tests** in the library correctly and I think it shouldn't be a problem since SQLException and ConnectionException both extends POMMException.

Let me know what you think about this.

