### PR TITLE
enable telemetry extension on CI builds

### DIFF
--- a/.atoum.php
+++ b/.atoum.php
@@ -1,0 +1,17 @@
+<?php
+
+use mageekguy\atoum\writers\std;
+use mageekguy\atoum\reports\telemetry;
+
+$script->addDefaultReport();
+
+if (class_exists('mageekguy\atoum\reports\telemetry') === true)
+{
+    $telemetry = new telemetry();
+    $telemetry->readProjectNameFromComposerJson(__DIR__ . '/composer.json');
+    $telemetry->addWriter(new std\out());
+    $runner->addReport($telemetry);
+}
+
+$script->noCodeCoverage();
+$script->addTestsFromDirectory(__DIR__ . '/sources/tests/Unit');

--- a/.bootstrap.atoum.php
+++ b/.bootstrap.atoum.php
@@ -1,6 +1,5 @@
 <?php
 set_error_handler(function($errno, $errstr, $errfile, $errline) { throw new ErrorException($errstr, 0, $errno, $errfile, $errline); });
-$loader = require __DIR__ . '/vendor/autoload.php';
 $file = __DIR__.'/sources/tests/config.php';
 
 if (file_exists($file)) {

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ before_script:
   - psql -c 'CREATE DATABASE pomm_test' -U postgres -h 127.0.0.1 postgres
   - psql -c 'CREATE EXTENSION hstore' -U postgres -h 127.0.0.1 pomm_test
   - psql -c 'CREATE EXTENSION ltree' -U postgres -h 127.0.0.1 pomm_test
-install: composer install --dev
-script: php vendor/atoum/atoum/bin/atoum --no-code-coverage -d sources/tests/Unit/
+install:
+  - composer require --dev 'atoum/reports-extension:^2.0.1'
+script:
+  - vendor/bin/atoum
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "atoum/atoum" : "dev-master"
+        "atoum/atoum" : "^2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "eec484a7559511a3ae18f7d9a974f459",
-    "content-hash": "9d0c033ae292cb24afa5537f690c3860",
+    "hash": "629ddc0bd1d3301be38dd11ee2ad3cf9",
+    "content-hash": "bc8c2ec26d7a9692bc31923976e30de7",
     "packages": [
         {
             "name": "psr/log",
@@ -49,16 +49,16 @@
     "packages-dev": [
         {
             "name": "atoum/atoum",
-            "version": "dev-master",
+            "version": "2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/atoum/atoum.git",
-                "reference": "bc1105cba8446bdd82d861d49096fa303aca49ea"
+                "reference": "1813c5f50d4727cc4be8ec9abe25befae78ce4c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/atoum/atoum/zipball/bc1105cba8446bdd82d861d49096fa303aca49ea",
-                "reference": "bc1105cba8446bdd82d861d49096fa303aca49ea",
+                "url": "https://api.github.com/repos/atoum/atoum/zipball/1813c5f50d4727cc4be8ec9abe25befae78ce4c5",
+                "reference": "1813c5f50d4727cc4be8ec9abe25befae78ce4c5",
                 "shasum": ""
             },
             "require": {
@@ -92,7 +92,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
@@ -125,14 +125,12 @@
                 "test",
                 "unit testing"
             ],
-            "time": "2015-10-01 20:37:42"
+            "time": "2016-07-01 15:49:14"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "atoum/atoum": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
This PR enables the telemetry reports on CI builds. It will let you (ans us at @atoum/core) track your tests suites (duration, memory, size, ...)

I also updated your configuration to let you use a atoum with the simplest possible command: `vendor/bin/atoum` (`--no-code-coverage` and `-d` are no more required)
