### PR TITLE
add citext type to string converter. Fix #84

### DIFF
--- a/sources/lib/SessionBuilder.php
+++ b/sources/lib/SessionBuilder.php
@@ -108,6 +108,7 @@ class SessionBuilder extends VanillaSessionBuilder
                     'varchar', 'pg_catalog.varchar',
                     'char', 'pg_catalog.char',
                     'text', 'pg_catalog.text',
+                    'citext', 'public.citext',
                     'uuid', 'pg_catalog.uuid',
                     'tsvector', 'pg_catalog.tsvector',
                     'xml', 'pg_catalog.xml',


### PR DESCRIPTION
See #84

I think if the extension is not enabled in the `public` schema this addition will not work.
I don't know if I have to add tests, I see nothin about testing types in a converter.