### PR TITLE
fix range converters for tsrange and numrange

### DIFF
--- a/sources/lib/Converter/Type/BaseRange.php
+++ b/sources/lib/Converter/Type/BaseRange.php
@@ -22,6 +22,10 @@ namespace PommProject\Foundation\Converter\Type;
  */
 abstract class BaseRange
 {
+    const INFINITY_MAX = 'infinity';
+    const INFINITY_MIN = '-infinity';
+    const EMPTY        = 'empty';
+
     public $start_limit;
     public $end_limit;
     public $start_incl;
@@ -66,22 +70,29 @@ abstract class BaseRange
      * @param  string $description
      * @throws \InvalidArgumentException
      */
-
     public function __construct($description)
     {
         if (!preg_match($this->getRegexp(), $description, $matches)) {
             throw new \InvalidArgumentException(
                 sprintf(
-                    "Could not parse NumRange description '%s'.",
+                    "Could not parse range description '%s'.",
                     $description
                 )
             );
         }
 
-        $this->start_limit = $this->getSubElement($matches[2]);
-        $this->end_limit   = $this->getSubElement($matches[3]);
-        $this->start_incl  = (bool) ($matches[1] === '[');
-        $this->end_incl    = (bool) ($matches[4] === ']');
+        if (count($matches) === 2) {
+            $this->start_limit = self::EMPTY;
+            $this->end_limit   = self::EMPTY;
+            $this->start_incl  = null;
+            $this->end_incl    = null;
+        } else {
+            $this->start_limit = $this->getSubElement($matches[3]);
+            $this->end_limit   = $this->getSubElement($matches[4]);
+            $this->start_incl  = (bool) ($matches[2] === '[');
+            $this->end_incl    = (bool) ($matches[5] === ']');
+        }
+
         $this->description = $description;
     }
 

--- a/sources/lib/Converter/Type/BaseRange.php
+++ b/sources/lib/Converter/Type/BaseRange.php
@@ -24,7 +24,7 @@ abstract class BaseRange
 {
     const INFINITY_MAX = 'infinity';
     const INFINITY_MIN = '-infinity';
-    const EMPTY        = 'empty';
+    const EMPTY_RANGE  = 'empty';
 
     public $start_limit;
     public $end_limit;
@@ -82,8 +82,8 @@ abstract class BaseRange
         }
 
         if (count($matches) === 2) {
-            $this->start_limit = self::EMPTY;
-            $this->end_limit   = self::EMPTY;
+            $this->start_limit = self::EMPTY_RANGE;
+            $this->end_limit   = self::EMPTY_RANGE;
             $this->start_incl  = null;
             $this->end_incl    = null;
         } else {

--- a/sources/lib/Converter/Type/NumRange.php
+++ b/sources/lib/Converter/Type/NumRange.php
@@ -28,7 +28,7 @@ class NumRange extends BaseRange
      */
     protected function getRegexp()
     {
-        return '/([\[\(])(-?[0-9\.]+), *(-?[0-9\.]+)([\]\)])/';
+        return '/(empty)|([\[\(])(-?[0-9\.]+)?, *(-?[0-9\.]+)?([\]\)])/';
     }
 
     /**
@@ -38,6 +38,6 @@ class NumRange extends BaseRange
      */
     protected function getSubElement($element)
     {
-        return $element + 0;
+        return $element !== '' ? $element + 0 : null;
     }
 }

--- a/sources/lib/Converter/Type/TsRange.php
+++ b/sources/lib/Converter/Type/TsRange.php
@@ -28,7 +28,7 @@ class TsRange extends BaseRange
      */
     protected function getRegexp()
     {
-        return '/([\[\(])"?([0-9 :+\.-]+)"?, *"?([0-9 :+\.-]+)"?([\]\)])/';
+        return '/(empty)|([\[\(])"?([0-9 :+\.-]+|-?infinity)?"?, *"?([0-9 :+\.-]+|-?infinity)?"?([\]\)])/';
     }
 
     /**
@@ -38,6 +38,17 @@ class TsRange extends BaseRange
      */
     protected function getSubElement($element)
     {
+        if ($element === BaseRange::INFINITY_MIN) {
+
+            return BaseRange::INFINITY_MIN;
+        } elseif ($element === BaseRange::INFINITY_MAX) {
+
+            return BaseRange::INFINITY_MAX;
+        } elseif ($element === '') {
+
+            return null;
+        }
+
         return new \DateTime($element);
     }
 }

--- a/sources/tests/Unit/Converter/PgNumRange.php
+++ b/sources/tests/Unit/Converter/PgNumRange.php
@@ -52,8 +52,8 @@ class PgNumRange extends BaseConverter
                 [
                     'assert'               => 'Test with empty',
                     'text_range'           => 'empty',
-                    'expected_start_limit' => BaseRange::EMPTY,
-                    'expected_end_limit'   => BaseRange::EMPTY,
+                    'expected_start_limit' => BaseRange::EMPTY_RANGE,
+                    'expected_end_limit'   => BaseRange::EMPTY_RANGE,
                     'expected_start_incl'  => null,
                     'expected_end_incl'    => null,
                 ],

--- a/sources/tests/Unit/Converter/PgNumRange.php
+++ b/sources/tests/Unit/Converter/PgNumRange.php
@@ -9,11 +9,81 @@
  */
 namespace PommProject\Foundation\Test\Unit\Converter;
 
+use PommProject\Foundation\Converter\Type\BaseRange;
 use PommProject\Foundation\Test\Unit\Converter\BaseConverter;
 use PommProject\Foundation\Converter\Type\NumRange;
 
 class PgNumRange extends BaseConverter
 {
+    protected function fromPgDataProvider()
+    {
+        return [
+            [
+                [
+                    'assert'               => 'Test with value and null',
+                    'text_range'           => '(-10,)',
+                    'expected_start_limit' => -10,
+                    'expected_end_limit'   => null,
+                    'expected_start_incl'  => false,
+                    'expected_end_incl'    => false,
+                ],
+            ],
+            [
+                [
+                    'assert'               => 'Test with null and null',
+                    'text_range'           => '[,]',
+                    'expected_start_limit' => null,
+                    'expected_end_limit'   => null,
+                    'expected_start_incl'  => true,
+                    'expected_end_incl'    => true,
+                ],
+            ],
+            [
+                [
+                    'assert'               => 'Test with null and value',
+                    'text_range'           => '(, 99)',
+                    'expected_start_limit' => null,
+                    'expected_end_limit'   => 99,
+                    'expected_start_incl'  => false,
+                    'expected_end_incl'    => false,
+                ],
+            ],
+            [
+                [
+                    'assert'               => 'Test with empty',
+                    'text_range'           => 'empty',
+                    'expected_start_limit' => BaseRange::EMPTY,
+                    'expected_end_limit'   => BaseRange::EMPTY,
+                    'expected_start_incl'  => null,
+                    'expected_end_incl'    => null,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array $data
+     * @dataProvider fromPgDataProvider
+     */
+    public function testExtraFromPg($data)
+    {
+        $session = $this->buildSession();
+        $this
+            ->assert($data['assert'])
+            ->given($instance = $this->newTestedInstance()->fromPg($data['text_range'], 'tstzrange', $session))
+            ->object($instance)
+            ->isInstanceOf('\PommProject\Foundation\Converter\Type\NumRange')
+            ->variable($instance->start_limit)
+            ->isEqualTo($data['expected_start_limit'])
+            ->variable($instance->end_limit)
+            ->isEqualTo($data['expected_end_limit'])
+            ->variable($instance->start_incl)
+            ->isEqualTo($data['expected_start_incl'])
+            ->variable($instance->end_incl)
+            ->isEqualTo($data['expected_end_incl'])
+        ;
+    }
+
     public function testFromPg()
     {
         $session = $this->buildSession();

--- a/sources/tests/Unit/Converter/PgTsRange.php
+++ b/sources/tests/Unit/Converter/PgTsRange.php
@@ -62,8 +62,8 @@ class PgTsRange extends BaseConverter
                 [
                     'assert'               => 'Test with empty',
                     'text_range'           => 'empty',
-                    'expected_start_limit' => BaseRange::EMPTY,
-                    'expected_end_limit'   => BaseRange::EMPTY,
+                    'expected_start_limit' => BaseRange::EMPTY_RANGE,
+                    'expected_end_limit'   => BaseRange::EMPTY_RANGE,
                     'expected_start_incl'  => null,
                     'expected_end_incl'    => null,
                 ],

--- a/sources/tests/Unit/Converter/PgTsRange.php
+++ b/sources/tests/Unit/Converter/PgTsRange.php
@@ -9,11 +9,91 @@
  */
 namespace PommProject\Foundation\Test\Unit\Converter;
 
+use PommProject\Foundation\Converter\Type\BaseRange;
 use PommProject\Foundation\Test\Unit\Converter\BaseConverter;
 use PommProject\Foundation\Converter\Type\TsRange;
 
 class PgTsRange extends BaseConverter
 {
+    protected function fromPgDataProvider()
+    {
+        return [
+            [
+                [
+                    'assert'               => 'Test with infinity and null',
+                    'text_range'           => '(infinity,)',
+                    'expected_start_limit' => BaseRange::INFINITY_MAX,
+                    'expected_end_limit'   => null,
+                    'expected_start_incl'  => false,
+                    'expected_end_incl'    => false,
+                ],
+            ],
+            [
+                [
+                    'assert'               => 'Test with null and null',
+                    'text_range'           => '[,]',
+                    'expected_start_limit' => null,
+                    'expected_end_limit'   => null,
+                    'expected_start_incl'  => true,
+                    'expected_end_incl'    => true,
+                ],
+            ],
+            [
+                [
+                    'assert'               => 'Test with null and minus infinity',
+                    'text_range'           => '(, -infinity)',
+                    'expected_start_limit' => null,
+                    'expected_end_limit'   => BaseRange::INFINITY_MIN,
+                    'expected_start_incl'  => false,
+                    'expected_end_incl'    => false,
+                ],
+            ],
+            [
+                [
+                    'assert'               => 'Test with infinities',
+                    'text_range'           => '(-infinity, infinity)',
+                    'expected_start_limit' => BaseRange::INFINITY_MIN,
+                    'expected_end_limit'   => BaseRange::INFINITY_MAX,
+                    'expected_start_incl'  => false,
+                    'expected_end_incl'    => false,
+                ],
+            ],
+            [
+                [
+                    'assert'               => 'Test with empty',
+                    'text_range'           => 'empty',
+                    'expected_start_limit' => BaseRange::EMPTY,
+                    'expected_end_limit'   => BaseRange::EMPTY,
+                    'expected_start_incl'  => null,
+                    'expected_end_incl'    => null,
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array $data
+     * @dataProvider fromPgDataProvider
+     */
+    public function testExtraFromPg($data)
+    {
+        $session = $this->buildSession();
+        $this
+            ->assert($data['assert'])
+            ->given($instance = $this->newTestedInstance()->fromPg($data['text_range'], 'tstzrange', $session))
+            ->object($instance)
+            ->isInstanceOf('\PommProject\Foundation\Converter\Type\TsRange')
+            ->variable($instance->start_limit)
+            ->isEqualTo($data['expected_start_limit'])
+            ->variable($instance->end_limit)
+            ->isEqualTo($data['expected_end_limit'])
+            ->variable($instance->start_incl)
+            ->isEqualTo($data['expected_start_incl'])
+            ->variable($instance->end_incl)
+            ->isEqualTo($data['expected_end_incl'])
+        ;
+    }
+
     public function testFromPg()
     {
         $session = $this->buildSession();


### PR DESCRIPTION
- `empty` is handled
- `infinity` and `-infinity` are handled for tsrange
- null values are handled. Ex: `(,)`

Closes #91