### PR TITLE
ResultHandler->getFieldNumber optimization

### DIFF
--- a/sources/lib/Session/ResultHandler.php
+++ b/sources/lib/Session/ResultHandler.php
@@ -194,7 +194,7 @@ class ResultHandler
      */
     protected function getFieldNumber($name)
     {
-        $no = pg_field_num($this->handler, "\"$name\""));
+        $no = pg_field_num($this->handler, "\"$name\"");
 
         if ($no ===  -1) {
             throw new \InvalidArgumentException(

--- a/sources/lib/Session/ResultHandler.php
+++ b/sources/lib/Session/ResultHandler.php
@@ -194,7 +194,7 @@ class ResultHandler
      */
     protected function getFieldNumber($name)
     {
-        $no = pg_field_num($this->handler, sprintf('"%s"', $name));
+        $no = pg_field_num($this->handler, "\"$name\""));
 
         if ($no ===  -1) {
             throw new \InvalidArgumentException(


### PR DESCRIPTION
I've profiled an application with a SQL query that returns tons of fields, and Blackfire flagged the `ResultHandler->getFieldNumber` as a performance bottleneck.
It was called 12 078 times, and 98% of the time spent on method was due to a call on `sprintf`.
Doing a concatenation instead solved that specific bottleneck.

Here's the profiler graph:

![profiler graph](https://i.imgur.com/zHUHKZX.png).

Do you think the change is worth it?