### PR TITLE
enhance result iterator performances

### DIFF
--- a/sources/lib/ConvertedResultIterator.php
+++ b/sources/lib/ConvertedResultIterator.php
@@ -65,7 +65,17 @@ class ConvertedResultIterator extends ResultIterator
     protected function initTypes()
     {
         foreach ($this->result->getFieldNames() as $index => $name) {
-            $this->types[$index] = $this->result->getFieldType($name);
+            $type = $this->result->getFieldType($name);
+
+            if ($type === null) {
+                $type = 'text';
+            }
+
+            $this->types[$name] = $type;
+            $this->converters[$name] = $this
+                ->session
+                ->getClientUsingPooler('converter', $type)
+            ;
         }
 
         return $this;
@@ -102,22 +112,9 @@ class ConvertedResultIterator extends ResultIterator
      */
     protected function convertField($name, $value)
     {
-        $type = $this->result->getFieldType($name);
-
-        if ($type === null) {
-            $type = 'text';
-        }
-
-        if (!isset($this->converters[$type])) {
-            $this->converters[$type] = $this
-                ->session
-                ->getClientUsingPooler('converter', $type)
-                ;
-        }
-
         return $this
-            ->converters[$type]
-            ->fromPg($value, $type)
+            ->converters[$name]
+            ->fromPg($value, $this->types[$name])
             ;
     }
 

--- a/sources/lib/ResultIterator.php
+++ b/sources/lib/ResultIterator.php
@@ -28,6 +28,7 @@ class ResultIterator implements ResultIteratorInterface, \JsonSerializable
 {
     private $position;
     protected $result;
+    private $rows_count;
 
     /**
      * __construct
@@ -101,7 +102,11 @@ class ResultIterator implements ResultIteratorInterface, \JsonSerializable
      */
     public function count()
     {
-        return $this->result->countRows();
+        if ($this->rows_count == null) {
+            $this->rows_count = $this->result->countRows();
+        }
+
+        return $this->rows_count;
     }
 
     /**
@@ -121,7 +126,7 @@ class ResultIterator implements ResultIteratorInterface, \JsonSerializable
      */
     public function current()
     {
-        return !$this->isEmpty()
+        return (($this->rows_count != null && $this->rows_count > 0 ) || !$this->isEmpty())
             ? $this->get($this->position)
             : null
             ;
@@ -198,7 +203,7 @@ class ResultIterator implements ResultIteratorInterface, \JsonSerializable
      */
     public function isEmpty()
     {
-        return $this->result->countRows() === 0;
+        return (($this->rows_count != null && $this->rows_count === 0 ) || $this->count() === 0);
     }
 
     /**


### PR DESCRIPTION
After a quick bench, it appears some cache could be applied on the
result iterator. This makes a ×2 speed performances when fetching large
amount of data (tested with 10k rows results).

cherry-pick 3e16b9f