### PR TITLE
Have separate converters to int and float.

### DIFF
--- a/sources/lib/Converter/PgFloat.php
+++ b/sources/lib/Converter/PgFloat.php
@@ -1,0 +1,70 @@
+<?php
+/*
+ * This file is part of Pomm's Foundation package.
+ *
+ * (c) 2014 - 2017 Grégoire HUBERT <hubert.greg@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PommProject\Foundation\Converter;
+
+use PommProject\Foundation\Session\Session;
+
+/**
+ * PgFloat
+ *
+ * Converter for numbers.
+ *
+ * @package   Foundation
+ * @copyright 2014 - 2017 Grégoire HUBERT
+ * @author    Grégoire HUBERT
+ * @license   X11 {@link http://opensource.org/licenses/mit-license.php}
+ * @see       ConverterInterface
+ */
+class PgFloat implements ConverterInterface
+{
+    /**
+     * fromPg
+     *
+     * @see ConverterInterface
+     */
+    public function fromPg($data, $type, Session $session)
+    {
+        $data = trim($data);
+
+        if ($data === '') {
+            return null;
+        }
+
+        return (float)$data;
+    }
+
+    /**
+     * toPg
+     *
+     * @see ConverterInterface
+     */
+    public function toPg($data, $type, Session $session)
+    {
+        return
+            $data !== null
+            ? sprintf("%s '%f'", $type, $data)
+            : sprintf("NULL::%s", $type)
+            ;
+    }
+
+    /**
+     * toPgStandardFormat
+     *
+     * @see ConverterInterface
+     */
+    public function toPgStandardFormat($data, $type, Session $session)
+    {
+        return
+            $data !== null
+            ? sprintf('%f', $data)
+            : null
+            ;
+    }
+}

--- a/sources/lib/Converter/PgFloat.php
+++ b/sources/lib/Converter/PgFloat.php
@@ -49,7 +49,7 @@ class PgFloat implements ConverterInterface
     {
         return
             $data !== null
-            ? sprintf("%s '%f'", $type, $data)
+            ? sprintf("%s '%s'", $type, $data)
             : sprintf("NULL::%s", $type)
             ;
     }
@@ -63,7 +63,7 @@ class PgFloat implements ConverterInterface
     {
         return
             $data !== null
-            ? sprintf('%f', $data)
+            ? sprintf('%s', $data)
             : null
             ;
     }

--- a/sources/lib/Converter/PgInteger.php
+++ b/sources/lib/Converter/PgInteger.php
@@ -12,7 +12,7 @@ namespace PommProject\Foundation\Converter;
 use PommProject\Foundation\Session\Session;
 
 /**
- * PgNumber
+ * PgInteger
  *
  * Converter for numbers.
  *
@@ -22,7 +22,7 @@ use PommProject\Foundation\Session\Session;
  * @license   X11 {@link http://opensource.org/licenses/mit-license.php}
  * @see       ConverterInterface
  */
-class PgNumber implements ConverterInterface
+class PgInteger implements ConverterInterface
 {
     /**
      * fromPg
@@ -37,7 +37,7 @@ class PgNumber implements ConverterInterface
             return null;
         }
 
-        return $data + 0;
+        return (int)$data;
     }
 
     /**
@@ -49,7 +49,7 @@ class PgNumber implements ConverterInterface
     {
         return
             $data !== null
-            ? sprintf("%s '%s'", $type, $data + 0)
+            ? sprintf("%s '%u'", $type, $data)
             : sprintf("NULL::%s", $type)
             ;
     }
@@ -63,7 +63,7 @@ class PgNumber implements ConverterInterface
     {
         return
             $data !== null
-            ? sprintf("%s", $data + 0)
+            ? sprintf('%u', $data)
             : null
             ;
     }

--- a/sources/lib/SessionBuilder.php
+++ b/sources/lib/SessionBuilder.php
@@ -88,16 +88,23 @@ class SessionBuilder extends VanillaSessionBuilder
                 false
             )
             ->registerConverter(
-                'Number',
-                new Converter\PgNumber(),
+                'Integer',
+                new Converter\PgInteger(),
                 [
                     'int2', 'pg_catalog.int2',
                     'int4', 'pg_catalog.int4', 'int', 'integer',
                     'int8', 'pg_catalog.int8',
+                    'oid', 'pg_catalog.oid',
+                ],
+                false
+            )
+            ->registerConverter(
+                'Float',
+                new Converter\PgFloat(),
+                [
                     'numeric', 'pg_catalog.numeric',
                     'float4', 'pg_catalog.float4', 'float',
                     'float8', 'pg_catalog.float8',
-                    'oid', 'pg_catalog.oid',
                 ],
                 false
             )

--- a/sources/tests/Unit/Converter/PgFloat.php
+++ b/sources/tests/Unit/Converter/PgFloat.php
@@ -19,9 +19,9 @@ class PgFloat extends BaseConverter
         $this
             ->variable($this->newTestedInstance()->fromPg(null, 'int4', $session))
             ->isNull()
-            ->integer($this->newTestedInstance()->fromPg('0', 'int4', $session))
+            ->float($this->newTestedInstance()->fromPg('0', 'int4', $session))
             ->isEqualTo(0)
-            ->integer($this->newTestedInstance()->fromPg('2015', 'int4', $session))
+            ->float($this->newTestedInstance()->fromPg('2015', 'int4', $session))
             ->isEqualTo(2015)
             ->float($this->newTestedInstance()->fromPg('3.141596', 'float4', $session))
             ->isEqualTo(3.141596)
@@ -32,14 +32,14 @@ class PgFloat extends BaseConverter
     {
         $session = $this->buildSession();
         $this
-            ->string($this->newTestedInstance()->toPg(2014, 'int4', $session))
-            ->isEqualTo("int4 '2014'")
+            ->string($this->newTestedInstance()->toPg(2014, 'float8', $session))
+            ->isEqualTo("float8 '2014'")
             ->string($this->newTestedInstance()->toPg(1.6180339887499, 'float8', $session))
             ->isEqualTo("float8 '1.6180339887499'")
-            ->string($this->newTestedInstance()->toPg(null, 'int4', $session))
-            ->isEqualTo("NULL::int4")
-            ->string($this->newTestedInstance()->toPg(0, 'int4', $session))
-            ->isEqualTo("int4 '0'")
+            ->string($this->newTestedInstance()->toPg(null, 'float8', $session))
+            ->isEqualTo("NULL::float8")
+            ->string($this->newTestedInstance()->toPg(0, 'float8', $session))
+            ->isEqualTo("float8 '0'")
         ;
     }
 
@@ -47,11 +47,11 @@ class PgFloat extends BaseConverter
     {
         $session = $this->buildSession();
         $this
-            ->string($this->newTestedInstance()->toPgStandardFormat(2014, 'int4', $session))
+            ->string($this->newTestedInstance()->toPgStandardFormat(2014, 'float8', $session))
             ->isEqualTo("2014")
             ->string($this->newTestedInstance()->toPgStandardFormat(1.6180339887499, 'float8', $session))
             ->isEqualTo("1.6180339887499")
-            ->variable($this->newTestedInstance()->toPgStandardFormat(null, 'int4', $session))
+            ->variable($this->newTestedInstance()->toPgStandardFormat(null, 'float8', $session))
             ->isNull()
             ;
     }

--- a/sources/tests/Unit/Converter/PgFloat.php
+++ b/sources/tests/Unit/Converter/PgFloat.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * This file is part of the PommProject/Foundation package.
+ *
+ * (c) 2014 - 2015 Grégoire HUBERT <hubert.greg@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace PommProject\Foundation\Test\Unit\Converter;
+
+use PommProject\Foundation\Test\Unit\Converter\BaseConverter;
+
+class PgFloat extends BaseConverter
+{
+    public function testFromPg()
+    {
+        $session = $this->buildSession();
+        $this
+            ->variable($this->newTestedInstance()->fromPg(null, 'int4', $session))
+            ->isNull()
+            ->integer($this->newTestedInstance()->fromPg('0', 'int4', $session))
+            ->isEqualTo(0)
+            ->integer($this->newTestedInstance()->fromPg('2015', 'int4', $session))
+            ->isEqualTo(2015)
+            ->float($this->newTestedInstance()->fromPg('3.141596', 'float4', $session))
+            ->isEqualTo(3.141596)
+            ;
+    }
+
+    public function testToPg()
+    {
+        $session = $this->buildSession();
+        $this
+            ->string($this->newTestedInstance()->toPg(2014, 'int4', $session))
+            ->isEqualTo("int4 '2014'")
+            ->string($this->newTestedInstance()->toPg(1.6180339887499, 'float8', $session))
+            ->isEqualTo("float8 '1.6180339887499'")
+            ->string($this->newTestedInstance()->toPg(null, 'int4', $session))
+            ->isEqualTo("NULL::int4")
+            ->string($this->newTestedInstance()->toPg(0, 'int4', $session))
+            ->isEqualTo("int4 '0'")
+        ;
+    }
+
+    public function testToPgStandardFormat()
+    {
+        $session = $this->buildSession();
+        $this
+            ->string($this->newTestedInstance()->toPgStandardFormat(2014, 'int4', $session))
+            ->isEqualTo("2014")
+            ->string($this->newTestedInstance()->toPgStandardFormat(1.6180339887499, 'float8', $session))
+            ->isEqualTo("1.6180339887499")
+            ->variable($this->newTestedInstance()->toPgStandardFormat(null, 'int4', $session))
+            ->isNull()
+            ;
+    }
+}

--- a/sources/tests/Unit/Converter/PgInteger.php
+++ b/sources/tests/Unit/Converter/PgInteger.php
@@ -23,7 +23,7 @@ class PgInteger extends BaseConverter
             ->isEqualTo(0)
             ->integer($this->newTestedInstance()->fromPg('2015', 'int4', $session))
             ->isEqualTo(2015)
-            ->float($this->newTestedInstance()->fromPg('3.141596', 'int4', $session))
+            ->integer($this->newTestedInstance()->fromPg('3.141596', 'int4', $session))
             ->isEqualTo(3)
             ;
     }

--- a/sources/tests/Unit/Converter/PgInteger.php
+++ b/sources/tests/Unit/Converter/PgInteger.php
@@ -11,7 +11,7 @@ namespace PommProject\Foundation\Test\Unit\Converter;
 
 use PommProject\Foundation\Test\Unit\Converter\BaseConverter;
 
-class PgNumber extends BaseConverter
+class PgInteger extends BaseConverter
 {
     public function testFromPg()
     {
@@ -23,8 +23,8 @@ class PgNumber extends BaseConverter
             ->isEqualTo(0)
             ->integer($this->newTestedInstance()->fromPg('2015', 'int4', $session))
             ->isEqualTo(2015)
-            ->float($this->newTestedInstance()->fromPg('3.141596', 'float4', $session))
-            ->isEqualTo(3.141596)
+            ->float($this->newTestedInstance()->fromPg('3.141596', 'int4', $session))
+            ->isEqualTo(3)
             ;
     }
 
@@ -34,8 +34,8 @@ class PgNumber extends BaseConverter
         $this
             ->string($this->newTestedInstance()->toPg(2014, 'int4', $session))
             ->isEqualTo("int4 '2014'")
-            ->string($this->newTestedInstance()->toPg(1.6180339887499, 'float8', $session))
-            ->isEqualTo("float8 '1.6180339887499'")
+            ->string($this->newTestedInstance()->toPg(1.6180339887499, 'int4', $session))
+            ->isEqualTo("int4 '1'")
             ->string($this->newTestedInstance()->toPg(null, 'int4', $session))
             ->isEqualTo("NULL::int4")
             ->string($this->newTestedInstance()->toPg(0, 'int4', $session))
@@ -49,8 +49,8 @@ class PgNumber extends BaseConverter
         $this
             ->string($this->newTestedInstance()->toPgStandardFormat(2014, 'int4', $session))
             ->isEqualTo("2014")
-            ->string($this->newTestedInstance()->toPgStandardFormat(1.6180339887499, 'float8', $session))
-            ->isEqualTo("1.6180339887499")
+            ->string($this->newTestedInstance()->toPgStandardFormat(1.6180339887499, 'int4', $session))
+            ->isEqualTo("1")
             ->variable($this->newTestedInstance()->toPgStandardFormat(null, 'int4', $session))
             ->isNull()
             ;


### PR DESCRIPTION
Right now, all number columns are converted to PHP variables by adding zero to the variable.
This works well in some cases, but we have noticed issues with certain objects (SimpleXML in our case) where doing this doesn't do the right thing. (It truncates the values after the decimal point.)