### PR TITLE
Persistent connections

### DIFF
--- a/documentation/foundation.rst
+++ b/documentation/foundation.rst
@@ -214,7 +214,7 @@ The ``dsn`` is the only mandatory parameter expected by the builder but more par
 - ``connection:configuration`` (array)
 - ``dsn`` (string) mandatory
 - ``class:session`` (string) default:  ``\PommProject\Foundation\Session\Session``
-- ``connection:persist`` (bool)
+- ``connection:persist`` (bool) default: ``false``
 
 The ``connection:configuration`` parameter contains a hashmap of postgresql settings (see `postgresql documentation <http://www.postgresql.org/docs/9.1/static/runtime-config-client.html>`_). The default settings are the following:
 

--- a/documentation/foundation.rst
+++ b/documentation/foundation.rst
@@ -214,6 +214,7 @@ The ``dsn`` is the only mandatory parameter expected by the builder but more par
 - ``connection:configuration`` (array)
 - ``dsn`` (string) mandatory
 - ``class:session`` (string) default:  ``\PommProject\Foundation\Session\Session``
+- ``connection:persist`` (bool)
 
 The ``connection:configuration`` parameter contains a hashmap of postgresql settings (see `postgresql documentation <http://www.postgresql.org/docs/9.1/static/runtime-config-client.html>`_). The default settings are the following:
 
@@ -221,6 +222,8 @@ The ``connection:configuration`` parameter contains a hashmap of postgresql sett
 - ``intervalstyle``               (string) default: ``ISO_8601``
 - ``datestyle``                   (string) default: ``ISO``
 - ``standard_conforming_strings`` (string) default: ``true``
+
+The ``connection:persist`` parameter allows persistent connections to the database (see `pg_connect() documentation <https://www.php.net/manual/en/function.pg-pconnect.php>`_). The default settings is to not use persistent connections.  Before enabling this setting, please be sure that you want this option turned on and know the limitations it brings.
 
 **dsn** is the only mandatory parameter, it is used to connect to the Postgresql database. The syntax is the following::
 

--- a/documentation/foundation.rst
+++ b/documentation/foundation.rst
@@ -223,7 +223,7 @@ The ``connection:configuration`` parameter contains a hashmap of postgresql sett
 - ``datestyle``                   (string) default: ``ISO``
 - ``standard_conforming_strings`` (string) default: ``true``
 
-The ``connection:persist`` parameter allows persistent connections to the database (see `pg_connect() documentation <https://www.php.net/manual/en/function.pg-pconnect.php>`_). The default settings is to not use persistent connections.  Before enabling this setting, please be sure that you want this option turned on and know the limitations it brings.
+The ``connection:persist`` parameter allows persistent connections to the database (see `pg_connect() documentation <https://www.php.net/manual/en/function.pg-pconnect.php>`_). The default setting is to not use persistent connections.  Before enabling this setting, please be sure that you want this option turned on and know the caveats it brings.
 
 **dsn** is the only mandatory parameter, it is used to connect to the Postgresql database. The syntax is the following::
 

--- a/sources/lib/Session/Connection.php
+++ b/sources/lib/Session/Connection.php
@@ -50,7 +50,7 @@ class Connection
      * @param  array $configuration
      * @throws ConnectionException if pgsql extension is missing
      */
-    public function __construct($dsn, bool $persist = false, array $configuration = [])
+    public function __construct($dsn, $persist = false, array $configuration = [])
     {
         if (!function_exists('pg_connection_status')) {
             $message = <<<ERROR

--- a/sources/lib/Session/Connection.php
+++ b/sources/lib/Session/Connection.php
@@ -46,10 +46,11 @@ class Connection
      * Constructor. Test if the given DSN is valid.
      *
      * @param  string $dsn
+     * @param  bool $persist
      * @param  array $configuration
      * @throws ConnectionException if pgsql extension is missing
      */
-    public function __construct($dsn, array $configuration = [])
+    public function __construct($dsn, bool $persist = false, array $configuration = [])
     {
         if (!function_exists('pg_connection_status')) {
             $message = <<<ERROR
@@ -60,7 +61,7 @@ ERROR;
             throw new ConnectionException($message);
         }
 
-        $this->configurator = new ConnectionConfigurator($dsn);
+        $this->configurator = new ConnectionConfigurator($dsn, $persist);
         $this->configurator->addConfiguration($configuration);
     }
 
@@ -208,9 +209,9 @@ ERROR;
         $persist = $this->configurator->getPersist();
 
         if ($persist) {
-            $handler = pg_connect($string, \PGSQL_CONNECT_FORCE_NEW);
-        } else {
             $handler = pg_pconnect($string);
+        } else {
+            $handler = pg_connect($string, \PGSQL_CONNECT_FORCE_NEW);
         }
 
         if ($handler === false) {

--- a/sources/lib/Session/Connection.php
+++ b/sources/lib/Session/Connection.php
@@ -205,7 +205,13 @@ ERROR;
     private function launch()
     {
         $string = $this->configurator->getConnectionString();
-        $handler = pg_connect($string, \PGSQL_CONNECT_FORCE_NEW);
+        $persist = $this->configurator->getPersist();
+
+        if ($persist) {
+            $handler = pg_connect($string, \PGSQL_CONNECT_FORCE_NEW);
+        } else {
+            $handler = pg_pconnect($string);
+        }
 
         if ($handler === false) {
             throw new ConnectionException(

--- a/sources/lib/Session/ConnectionConfigurator.php
+++ b/sources/lib/Session/ConnectionConfigurator.php
@@ -207,7 +207,7 @@ class ConnectionConfigurator
      *
      * @return bool
      */
-    public function getPersist(): bool
+    public function getPersist()
     {
         return $this->configuration['persist'];
     }

--- a/sources/lib/Session/ConnectionConfigurator.php
+++ b/sources/lib/Session/ConnectionConfigurator.php
@@ -35,7 +35,7 @@ class ConnectionConfigurator
      *
      * @param  array $dsn
      */
-    public function __construct($dsn, bool $persist = false)
+    public function __construct($dsn, $persist = false)
     {
         $this->configuration = new ParameterHolder(
             [

--- a/sources/lib/Session/ConnectionConfigurator.php
+++ b/sources/lib/Session/ConnectionConfigurator.php
@@ -35,12 +35,13 @@ class ConnectionConfigurator
      *
      * @param  array $dsn
      */
-    public function __construct($dsn)
+    public function __construct($dsn, bool $persist = false)
     {
         $this->configuration = new ParameterHolder(
             [
                 'dsn' => $dsn,
                 'configuration' => $this->getDefaultConfiguration(),
+                'persist' => $persist,
             ]
         );
         $this->parseDsn();
@@ -197,6 +198,18 @@ class ConnectionConfigurator
         }
 
         return join(' ', $connect_parameters);
+    }
+
+    /**
+     * getPersist
+     *
+     * Return whether or not to persist the connection to the DB.
+     *
+     * @return bool
+     */
+    public function getPersist(): bool
+    {
+        return $this->configuration['persist'];
     }
 
     /**

--- a/sources/lib/Session/SessionBuilder.php
+++ b/sources/lib/Session/SessionBuilder.php
@@ -107,8 +107,13 @@ class SessionBuilder
             ->mustHave('connection:configuration')
             ->getParameter('connection:configuration')
             ;
+        $persist =
+            $this->configuration
+            ->mustHave('connection:persist')
+            ->getParameter('connection:persist')
+            ;
         $session = $this->createSession(
-            $this->createConnection($dsn, $connection_configuration),
+            $this->createConnection($dsn, $persist, $connection_configuration),
             $this->createClientHolder(),
             $stamp
         );
@@ -137,7 +142,8 @@ class SessionBuilder
                     'datestyle'     => 'ISO',
                     'standard_conforming_strings' => 'true',
                     'timezone'      => date_default_timezone_get(),
-                ]
+                ],
+                'connection:persist' => false,
             ];
     }
 
@@ -160,12 +166,13 @@ class SessionBuilder
      * Connection instantiation.
      *
      * @param  string   $dsn
+     * @param  bool     $persist
      * @param  string|array $connection_configuration
      * @return Connection
      */
-    protected function createConnection($dsn, $connection_configuration)
+    protected function createConnection($dsn, bool $persist, $connection_configuration)
     {
-        return new Connection($dsn, $connection_configuration);
+        return new Connection($dsn, $persist, $connection_configuration);
     }
 
     /**

--- a/sources/lib/Session/SessionBuilder.php
+++ b/sources/lib/Session/SessionBuilder.php
@@ -170,7 +170,7 @@ class SessionBuilder
      * @param  string|array $connection_configuration
      * @return Connection
      */
-    protected function createConnection($dsn, bool $persist, $connection_configuration)
+    protected function createConnection($dsn, $persist, $connection_configuration)
     {
         return new Connection($dsn, $persist, $connection_configuration);
     }


### PR DESCRIPTION
Add in a new configuration option to allow persistent connections (through using `pg_pconnect()`).