### PR TITLE
update travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,14 @@
 language: php
 
 php:
-  - "5.6"
-  - "7.0"
-  - "7.1"
-  - "7.2"
   - "7.3"
-  - "nightly"
-
-matrix:
-  allow_failures:
-    - php: "nightly"
-
-env:
-    matrix:
-        - DEPS=hight
-        - DEPS=low
+  - "7.4"
+  - "8.0"
 
 services: postgresql
 
 addons:
-    postgresql: "9.4"
+    postgresql: "10"
 
 before_script:
   - psql -c 'CREATE DATABASE pomm_test' -U postgres -h 127.0.0.1 postgres
@@ -29,8 +17,6 @@ before_script:
 
 install:
   - composer install --dev
-  - test "$DEPS" == "hight" || composer update --prefer-lowest
-  - test "$DEPS" == "hight" || composer update atoum/atoum
 
 script:
   - ./vendor/bin/phpcs --standard=psr2 --runtime-set ignore_warnings_on_exit true --report=summary sources

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ php:
   - "7.4"
   - "8.0"
 
+matrix:
+  allow_failures:
+    - php: "8.0"
+
 services: postgresql
 
 addons:


### PR DESCRIPTION
Reduces the test matrix down to PHP 7.3, 7.4 and waiting for travis to support 8.0