### PR TITLE
fix Atoum version for old version of PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ before_script:
   - php vendor/atoum/atoum/bin/atoum --version
 install:
     - composer install --dev
-    - test "$TRAVIS_PHP_VERSION" == "5.6" -o "$TRAVIS_PHP_VERSION" == "7.0" && composer update --prefer-lowest || composer update
+    - composer update
 script: php vendor/atoum/atoum/bin/atoum --no-code-coverage -d sources/tests/Unit/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ before_script:
   - psql -c 'CREATE EXTENSION hstore' -U postgres -h 127.0.0.1 pomm_test
   - psql -c 'CREATE EXTENSION ltree' -U postgres -h 127.0.0.1 pomm_test
   - php vendor/atoum/atoum/bin/atoum --version
-install: composer install --dev
+install:
+    - composer install --dev
+    - test "$TRAVIS_PHP_VERSION" == "5.6" -o "$TRAVIS_PHP_VERSION" == "7.0" && composer update --prefer-lowest || composer update
 script: php vendor/atoum/atoum/bin/atoum --no-code-coverage -d sources/tests/Unit/
 

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "atoum/atoum" : "^2.8 || ^4.0"
+        "atoum/atoum" : "^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The Travis test was failing for PHP7.1 because of the change of Atoum version to use the 4.0 which does not support PHP 7.1. The older version in composer was a 2.9 version that could not support PHP 7.1 either. 