### PR TITLE
Fix trim() notice with PHP8.1

### DIFF
--- a/sources/lib/Converter/PgBoolean.php
+++ b/sources/lib/Converter/PgBoolean.php
@@ -30,6 +30,9 @@ class PgBoolean implements ConverterInterface
      */
     public function fromPg($data, $type, Session $session)
     {
+        if (null === $data) {
+            return null;
+        }
         $data = trim($data);
 
         if (!preg_match('/^(t|f)$/', $data)) {

--- a/sources/lib/Converter/PgFloat.php
+++ b/sources/lib/Converter/PgFloat.php
@@ -31,6 +31,9 @@ class PgFloat implements ConverterInterface
      */
     public function fromPg($data, $type, Session $session)
     {
+        if (null === $data) {
+            return null;
+        }
         $data = trim($data);
 
         if ($data === '') {

--- a/sources/lib/Converter/PgInteger.php
+++ b/sources/lib/Converter/PgInteger.php
@@ -31,6 +31,9 @@ class PgInteger implements ConverterInterface
      */
     public function fromPg($data, $type, Session $session)
     {
+        if (null === $data) {
+            return null;
+        }
         $data = trim($data);
 
         if ($data === '') {

--- a/sources/lib/Converter/PgInterval.php
+++ b/sources/lib/Converter/PgInterval.php
@@ -29,6 +29,9 @@ class PgInterval implements ConverterInterface
      */
     public function fromPg($data, $type, Session $session)
     {
+        if (null === $data) {
+            return null;
+        }
         if (trim($data) === '') {
             return null;
         }

--- a/sources/lib/Converter/PgJson.php
+++ b/sources/lib/Converter/PgJson.php
@@ -47,6 +47,9 @@ class PgJson implements ConverterInterface
      */
     public function fromPg($data, $type, Session $session)
     {
+        if (null === $data) {
+            return null;
+        }
         if (trim($data) === '') {
             return null;
         }

--- a/sources/lib/Converter/PgLtree.php
+++ b/sources/lib/Converter/PgLtree.php
@@ -31,6 +31,9 @@ class PgLtree extends ArrayTypeConverter
      */
     public function fromPg($data, $type, Session $session)
     {
+        if (null === $data) {
+            return null;
+        }
         $data = trim($data);
 
         if ($data === '') {

--- a/sources/lib/Converter/PgTimestamp.php
+++ b/sources/lib/Converter/PgTimestamp.php
@@ -34,6 +34,9 @@ class PgTimestamp implements ConverterInterface
      */
     public function fromPg($data, $type, Session $session)
     {
+        if (null === $data) {
+            return null;
+        }
         $data = trim($data);
 
         return $data !== '' ? new \DateTime($data) : null;


### PR DESCRIPTION
Error message: 
 ```
Remaining indirect deprecation notices
  x: trim(): Passing null to parameter #1 ($string) of type string is deprecated
```