### PR TITLE
Hotfix Return type in php8

### DIFF
--- a/sources/lib/ParameterHolder.php
+++ b/sources/lib/ParameterHolder.php
@@ -153,7 +153,7 @@ class ParameterHolder implements \ArrayAccess, \IteratorAggregate, \Countable
      * @see ArrayAccess
      */
     #[\ReturnTypeWillChange]
-    public function offsetExists($name)
+    public function offsetExists($name): bool
     {
         return $this->hasParameter($name);
     }
@@ -164,7 +164,7 @@ class ParameterHolder implements \ArrayAccess, \IteratorAggregate, \Countable
      * @see ArrayAccess
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($name)
+    public function offsetGet($name): mixed
     {
         return $this->getParameter($name);
     }
@@ -175,7 +175,7 @@ class ParameterHolder implements \ArrayAccess, \IteratorAggregate, \Countable
      * @see ArrayAccess
      */
     #[\ReturnTypeWillChange]
-    public function offsetSet($name, $value)
+    public function offsetSet($name, $value): void
     {
         $this->setParameter($name, $value);
     }
@@ -186,7 +186,7 @@ class ParameterHolder implements \ArrayAccess, \IteratorAggregate, \Countable
      * @see ArrayAccess
      */
     #[\ReturnTypeWillChange]
-    public function offsetUnset($name)
+    public function offsetUnset($name): void
     {
         $this->unsetParameter($name);
     }
@@ -196,7 +196,7 @@ class ParameterHolder implements \ArrayAccess, \IteratorAggregate, \Countable
      * @see \Countable
      */
     #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return count($this->parameters);
     }
@@ -207,7 +207,7 @@ class ParameterHolder implements \ArrayAccess, \IteratorAggregate, \Countable
      * @see \IteratorAggregate
      */
     #[\ReturnTypeWillChange]
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->parameters);
     }

--- a/sources/lib/Pomm.php
+++ b/sources/lib/Pomm.php
@@ -339,7 +339,7 @@ class Pomm implements \ArrayAccess, LoggerAwareInterface
      * @see ArrayAccess
      */
     #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->getSession($offset);
     }
@@ -348,7 +348,7 @@ class Pomm implements \ArrayAccess, LoggerAwareInterface
      * @see ArrayAccess
      */
     #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->addBuilder($offset, $value);
     }
@@ -357,7 +357,7 @@ class Pomm implements \ArrayAccess, LoggerAwareInterface
      * @see ArrayAccess
      */
     #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->removeBuilder($offset);
     }
@@ -366,7 +366,7 @@ class Pomm implements \ArrayAccess, LoggerAwareInterface
      * @see ArrayAccess
      */
     #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->hasBuilder($offset);
     }

--- a/sources/lib/ResultIterator.php
+++ b/sources/lib/ResultIterator.php
@@ -294,7 +294,7 @@ class ResultIterator implements ResultIteratorInterface, \JsonSerializable
      * @see \JsonSerializable
      */
     #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->extract();
     }


### PR DESCRIPTION
Fix deprecated messages in PHP 8.1
```

 [info] User Deprecated: Method "ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "PommProject\Foundation\Pomm" now to avoid errors or add an explicit @return annotation to suppress this message.
2023-02-15T14:04:17+00:00 [info] User Deprecated: Method "ArrayAccess::offsetSet()" might add "void" as a native return type declaration in the future. Do the same in implementation "PommProject\Foundation\Pomm" now to avoid errors or add an explicit @return annotation to suppress this message.
2023-02-15T14:04:17+00:00 [info] User Deprecated: Method "ArrayAccess::offsetUnset()" might add "void" as a native return type declaration in the future. Do the same in implementation "PommProject\Foundation\Pomm" now to avoid errors or add an explicit @return annotation to suppress this message.
2023-02-15T14:04:17+00:00 [info] User Deprecated: Method "ArrayAccess::offsetExists()" might add "bool" as a native return type declaration in the future. Do the same in implementation "PommProject\Foundation\Pomm" now to avoid errors or add an explicit @return annotation to suppress this message.
2023-02-15T14:04:17+00:00 [info] User Deprecated: Method "ArrayAccess::offsetExists()" might add "bool" as a native return type declaration in the future. Do the same in implementation "PommProject\Foundation\ParameterHolder" now to avoid errors or add an explicit @return annotation to suppress this message.
2023-02-15T14:04:17+00:00 [info] User Deprecated: Method "ArrayAccess::offsetGet()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "PommProject\Foundation\ParameterHolder" now to avoid errors or add an explicit @return annotation to suppress this message.
2023-02-15T14:04:17+00:00 [info] User Deprecated: Method "ArrayAccess::offsetSet()" might add "void" as a native return type declaration in the future. Do the same in implementation "PommProject\Foundation\ParameterHolder" now to avoid errors or add an explicit @return annotation to suppress this message.
2023-02-15T14:04:17+00:00 [info] User Deprecated: Method "ArrayAccess::offsetUnset()" might add "void" as a native return type declaration in the future. Do the same in implementation "PommProject\Foundation\ParameterHolder" now to avoid errors or add an explicit @return annotation to suppress this message.
2023-02-15T14:04:17+00:00 [info] User Deprecated: Method "Countable::count()" might add "int" as a native return type declaration in the future. Do the same in implementation "PommProject\Foundation\ParameterHolder" now to avoid errors or add an explicit @return annotation to suppress this message.
2023-02-15T14:04:17+00:00 [info] User Deprecated: Method "IteratorAggregate::getIterator()" might add "\Traversable" as a native return type declaration in the future. Do the same in implementation "PommProject\Foundation\ParameterHolder" now to avoid errors or add an explicit @return annotation to suppress this message.
2023-02-15T14:04:17+00:00 [info] User Deprecated: Method "JsonSerializable::jsonSerialize()" might add "mixed" as a native return type declaration in the future. Do the same in implementation "PommProject\Foundation\ResultIterator" now to avoid errors or add an explicit @return annotation to suppress this message.

```